### PR TITLE
fix position of ToC line for custom sections

### DIFF
--- a/these.tex
+++ b/these.tex
@@ -15,16 +15,19 @@
 
 
 	\chapter*{Résumé}					%% résumé
+        \addcontentsline{toc}{chapter}{Résumé}
 	\input{tex/resume}
-	\addcontentsline{toc}{chapter}{Résumé}
+
 
 	\chapter*{Abstract}					%% abstract
+        \addcontentsline{toc}{chapter}{Abstract}
 	\input{tex/abstract}
-	\addcontentsline{toc}{chapter}{Abstract}
+
 
 	\chapter*{Remerciements}			%% remerciements
+        \addcontentsline{toc}{chapter}{Remerciements}
 	\input{tex/remercie}
-	\addcontentsline{toc}{chapter}{Remerciements}
+
 
 
     \microtypesetup{protrusion=false}	%% désactive la protrusion (TOC LOFT GLS)


### PR DESCRIPTION
The content line to the ToC should refer to the starting page of the section. If `\addcontentsline` is after the section, and the section is more than one page long, the ToC entry will point to the last page and not the first one. This fixes the order.