### PR TITLE
Fix numbering eq/fig/tab in appendices

### DIFF
--- a/tex_append/annexes.tex
+++ b/tex_append/annexes.tex
@@ -1,6 +1,11 @@
 \setcounter{chapter}{0}
 \renewcommand{\thesection}{\Alph{section}}
 
+% Fix numbering of eq/table/fig in appendices
+\numberwithin{equation}{section} % Restart number at each section
+\numberwithin{figure}{section}
+\numberwithin{table}{section}
+
 \chapter*{ANNEXES}
 \newpage
 \addcontentsline{toc}{chapter}{ANNEXES}


### PR DESCRIPTION
Set properly the numbering of eq/fig/tab in the appendices by resetting the numbering for each section, since each appendix is a section.

Before fix:

<img width="645" alt="problem-numbering-appendix" src="https://github.com/SCD-Aix-Marseille-Universite/latexamu/assets/38508580/6c731d19-b2e5-4afa-89e3-6f087117bdc5">

After fix:
<img width="645" alt="fix-problem-numbering-appendix" src="https://github.com/SCD-Aix-Marseille-Universite/latexamu/assets/38508580/3dcb198c-1208-4850-a9e0-9d7e2daad68f">
